### PR TITLE
Update chat_with_documents.py

### DIFF
--- a/chat_with_retrieval/chat_with_documents.py
+++ b/chat_with_retrieval/chat_with_documents.py
@@ -48,7 +48,7 @@ def configure_retriever(
     retriever = vectordb.as_retriever(
         search_type="mmr", search_kwargs={
             "k": 5,
-            "fetch_k": 4,
+            "fetch_k": 7,
             "include_metadata": True
         },
     )


### PR DESCRIPTION
Ideally `fetch_k` should be bigger than `k` parameter, since first it will fetch the `fetch_k` documents,

It will then select `k` document based on the search type.

Please correct me if i am wrong.

i got to know that from [issue](https://github.com/langchain-ai/langchain/issues/7829) and [langchain-chat-with-your-data-project -from-deeplearning.ai](https://www.coursera.org/learn/langchain-chat-with-your-data-project/) 