### PR TITLE
Updated comment in app.py - missleading instructions on how to run the app

### DIFF
--- a/chat_with_retrieval/app.py
+++ b/chat_with_retrieval/app.py
@@ -1,7 +1,7 @@
 """Document loading functionality.
 
 Run like this:
-> PYTHONPATH=. streamlit run chat_with_retrieval/chat_with_documents.py
+> PYTHONPATH=. streamlit run chat_with_retrieval/app.py
 """
 import logging
 


### PR DESCRIPTION
The previous comment pointed to chat_with_documents.py but the streamlit app is called app.py