### PR TITLE
[hotfix] add a manual model rebuild due to Pydantic v2 changes.

### DIFF
--- a/chapter2/chat_models.ipynb
+++ b/chapter2/chat_models.ipynb
@@ -99,10 +99,13 @@
     }
    ],
    "source": [
+    "from typing import Union\n",
+    "from langchain_core.caches import BaseCache\n",
+    "from langchain_core.callbacks.base import Callbacks\n",
     "from langchain_community.llms import FakeListLLM\n",
     "\n",
-    "# Create a fake LLM that always returns the same responses\n",
-    "fake_llm = FakeListLLM(responses=[\"Hello\"])\n",
+    "# Rebuild the model to satisfy Pydantic v2 validation\n",
+    "FakeListLLM.model_rebuild()\n",
     "\n",
     "result = fake_llm.invoke(\"Any input will return Hello\")\n",
     "print(result)  # Output: Hello"


### PR DESCRIPTION
Pydantic v2 has a stricter model initialization process. Classes like FakeListLLM are defined using Union[...] or lazy type annotations and require calling .model_rebuild() explicitly.

Pydantic v2 now eagerly evaluates type annotations during .model_rebuild(). Each time it encounters an unknown type name (like 'Callbacks', 'Union', 'BaseCache'), these types must be imported into the current Python scope before calling model_rebuild().