### PR TITLE
chore: update deprecated ChatGroq deepseek model to llama

### DIFF
--- a/chapter4/llms.py
+++ b/chapter4/llms.py
@@ -9,7 +9,7 @@ from config import set_environment
 set_environment()
 
 chat_model = ChatGroq(
-    model="deepseek-r1-distill-llama-70b",
+    model="llama-3.3-70b-versatile",
     temperature=0,
     max_tokens=None,
     timeout=None,


### PR DESCRIPTION
Update `decomissioneddeepseek-r1-distill-llama-70b` model for chapter 4 to `llama-3.3-70b-versatile` as recommended by documentation
[October 2, 2025: deepseek-r1-distill-llama-70b](https://console.groq.com/docs/deprecations#october-2-2025-deepseekr1distillllama70b)