### PR TITLE
Fix: Import issue and structured enum output deprecation fix

### DIFF
--- a/chapter6/tot.ipynb
+++ b/chapter6/tot.ipynb
@@ -95,7 +95,7 @@
       },
       "outputs": [],
       "source": [
-        "from langchain.agents import load_tools\n",
+        "from langchain_community.agent_toolkits.load_tools import load_tools\n",
         "from langgraph.prebuilt import create_react_agent\n",
         "\n",
         "llm = ChatGoogleGenerativeAI(model=\"gemini-2.5-flash\")\n",
@@ -357,9 +357,9 @@
         "      \"type\": \"STRING\",\n",
         "      \"enum\": [str(i+1) for i in range(len(all_candidates))]}\n",
         "  llm_enum = ChatGoogleGenerativeAI(\n",
-        "      model=\"gemini-2.5-flash\", response_mime_type=\"text/x.enum\",\n",
-        "      response_schema=response_schema)\n",
-        "  result = (prompt_voting | llm_enum | StrOutputParser()).invoke(\n",
+        "      model=\"gemini-2.5-flash\",\n",
+        "    ).with_structured_output(response_schema)\n",
+        "  result = (prompt_voting | llm_enum).invoke(\n",
         "      {\"candidates\": \"\\n\".join(all_candidates), \"task\": state[\"task\"]}\n",
         "  )\n",
         "  return {\"best_candidate\": candidates[int(result)-1]}\n"


### PR DESCRIPTION
**Fixes**

- `load_tools` import issue fix
- Update non-working legacy `response_mime_type='text/x.enum'` to `.with_structured_output()`.  Changing to their suggested JSON Schema output is not fit for purpose for this part of the tutorial as we want a fixed enum output instead. The `response_mime_type` approach does not enforce a structured output and we have to manually prompt these anyway as mentioned in [in the docs](https://reference.langchain.com/python/integrations/langchain_google_genai/ChatGoogleGenerativeAI/#langchain_google_genai.ChatGoogleGenerativeAI.response_mime_type). So I have gone for `.with_structured_output()` as a fix. Let me know if there is any conflicts on this end. 
<img width="920" height="480" alt="Screenshot 2026-01-25 at 13 42 37" src="https://github.com/user-attachments/assets/88e9e858-f511-470b-9944-bc6a032c4ef2" />
